### PR TITLE
Convert from "java" (deprecated as of 2016-12-31) to "openjdk"

### DIFF
--- a/2.3.0/community/Dockerfile
+++ b/2.3.0/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.0/enterprise/Dockerfile
+++ b/2.3.0/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.1/community/Dockerfile
+++ b/2.3.1/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.1/enterprise/Dockerfile
+++ b/2.3.1/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.2/community/Dockerfile
+++ b/2.3.2/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.2/enterprise/Dockerfile
+++ b/2.3.2/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.3/community/Dockerfile
+++ b/2.3.3/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.3/enterprise/Dockerfile
+++ b/2.3.3/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.4/community/Dockerfile
+++ b/2.3.4/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.4/enterprise/Dockerfile
+++ b/2.3.4/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.5/community/Dockerfile
+++ b/2.3.5/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.5/enterprise/Dockerfile
+++ b/2.3.5/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.6/community/Dockerfile
+++ b/2.3.6/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.6/enterprise/Dockerfile
+++ b/2.3.6/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.7/community/Dockerfile
+++ b/2.3.7/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.7/enterprise/Dockerfile
+++ b/2.3.7/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.8/community/Dockerfile
+++ b/2.3.8/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/2.3.8/enterprise/Dockerfile
+++ b/2.3.8/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/3.0.0/community/Dockerfile
+++ b/3.0.0/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 1f1aeb3c748d5b05c263b7dab8b195df788507f59228e80534ed8e506a80c517
 ENV NEO4J_TARBALL neo4j-community-3.0.0-unix.tar.gz

--- a/3.0.0/enterprise/Dockerfile
+++ b/3.0.0/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 376409e1849f2f13d5ea6ddc672b535646ffb9a24527520b661e044190bf617a
 ENV NEO4J_TARBALL neo4j-enterprise-3.0.0-unix.tar.gz

--- a/3.0.1/community/Dockerfile
+++ b/3.0.1/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 ae9d966559c83a9f1c61e1ef4d67aafeb9185e568b6dec0cd6b50e4297a15895
 ENV NEO4J_TARBALL neo4j-community-3.0.1-unix.tar.gz

--- a/3.0.1/enterprise/Dockerfile
+++ b/3.0.1/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 d88c107d10bc4d4919bbac775aa128b4c312a420abfd06897471b5fa96864b11
 ENV NEO4J_TARBALL neo4j-enterprise-3.0.1-unix.tar.gz

--- a/3.0.2/community/Dockerfile
+++ b/3.0.2/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 3daac469e0ad0f74eb8532ada8019b418e6ebd88da9bac52a4ee3393e18086aa
 ENV NEO4J_TARBALL neo4j-community-3.0.2-unix.tar.gz

--- a/3.0.2/enterprise/Dockerfile
+++ b/3.0.2/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 7e3cb1cb29c51ac267e57ec3d12c425bd31a4c92a2ecba70bb78360670b4b972
 ENV NEO4J_TARBALL neo4j-enterprise-3.0.2-unix.tar.gz

--- a/3.0.3/community/Dockerfile
+++ b/3.0.3/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 20cd65c84a6e5345f17bb03c145190f74e58ec2754c2e515a64b317e34dae2ce
 ENV NEO4J_TARBALL neo4j-community-3.0.3-unix.tar.gz

--- a/3.0.3/enterprise/Dockerfile
+++ b/3.0.3/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 f73ed4faf94087bded5ee34bc2614f09bbedc3b6e25439058526ce5506eb127e
 ENV NEO4J_TARBALL neo4j-enterprise-3.0.3-unix.tar.gz

--- a/3.0.4/community/Dockerfile
+++ b/3.0.4/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 e1da51163eb18380623788eabea34dfe23ee21c99deca4e7922094b0d242e805
 ENV NEO4J_URI http://dist.neo4j.org/neo4j-community-3.0.4-unix.tar.gz

--- a/3.0.4/enterprise/Dockerfile
+++ b/3.0.4/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 7cc47dcffdd040beec230cb6633bf03ace326218fa70f6d90612de057a6d61e2
 ENV NEO4J_URI http://dist.neo4j.org/neo4j-enterprise-3.0.4-unix.tar.gz

--- a/3.0.5/community/Dockerfile
+++ b/3.0.5/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 65f6995f9d2e87b61cb8d9c7623e9861bced555a8c05f3476aa73240a77437d8
 ENV NEO4J_TARBALL neo4j-community-3.0.5-unix.tar.gz

--- a/3.0.5/enterprise/Dockerfile
+++ b/3.0.5/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 069cd8b1eab4e4b20e4abb50a6f1e7c985a21ad349d3fe3413943b96f1724e06
 ENV NEO4J_TARBALL neo4j-enterprise-3.0.5-unix.tar.gz

--- a/3.0.6/community/Dockerfile
+++ b/3.0.6/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 efeab41183e9e5fa94a2d396c65ea93a24e9f105cb3b5f0d0a8e42fb709f4660
 ENV NEO4J_TARBALL neo4j-community-3.0.6-unix.tar.gz

--- a/3.0.6/enterprise/Dockerfile
+++ b/3.0.6/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 f58450760a92b0913c5418e26278a6a65bf6c5ba01f9b12a033f56e80f0c3d23
 ENV NEO4J_TARBALL neo4j-enterprise-3.0.6-unix.tar.gz

--- a/3.0.7/community/Dockerfile
+++ b/3.0.7/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 69f7b410934d0a83120f892c1f341905b3a9346656b5d085eca1da612b8e7ae6
 ENV NEO4J_TARBALL neo4j-community-3.0.7-unix.tar.gz

--- a/3.0.7/enterprise/Dockerfile
+++ b/3.0.7/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 92edf396616be8a1cdb41dd05c300865959f97944f4fe7f50539401a49c095d5
 ENV NEO4J_TARBALL neo4j-enterprise-3.0.7-unix.tar.gz

--- a/3.1.0-BETA1/community/Dockerfile
+++ b/3.1.0-BETA1/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/3.1.0-BETA1/enterprise/Dockerfile
+++ b/3.1.0-BETA1/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/3.1.0-M03/community/Dockerfile
+++ b/3.1.0-M03/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 f2f00dc94826f110b58aeed5dfc100a1c8f46a66c455db17c5238deb1b97901b
 ENV NEO4J_URI http://dist.neo4j.org/neo4j-community-3.1.0-M03-unix.tar.gz

--- a/3.1.0-M03/enterprise/Dockerfile
+++ b/3.1.0-M03/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 7c048f7883ac2147b4a83173d2e88d46e966ad47c07540ec593f83375970da76
 ENV NEO4J_URI http://dist.neo4j.org/neo4j-enterprise-3.1.0-M03-unix.tar.gz

--- a/3.1.0-M04/community/Dockerfile
+++ b/3.1.0-M04/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 143970ee788ac246cdec249ca9fefbeab2f1122255c9e9c1b655f688552acb05
 ENV NEO4J_URI http://dist.neo4j.org/neo4j-community-3.1.0-M04-unix.tar.gz

--- a/3.1.0-M04/enterprise/Dockerfile
+++ b/3.1.0-M04/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 6663985d3e07db9a3fb0d77ae3549f02ed87645a71d62b9d23ea2ae9c057a363
 ENV NEO4J_URI http://dist.neo4j.org/neo4j-enterprise-3.1.0-M04-unix.tar.gz

--- a/3.1.0-M05/community/Dockerfile
+++ b/3.1.0-M05/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 ccdd4b7d7320a0ecc78f9d8f26bc90d20de8d6ec3b517ffbc129ba9ff8d3f4d6
 ENV NEO4J_URI http://dist.neo4j.org/neo4j-community-3.1.0-M05-unix.tar.gz

--- a/3.1.0-M05/enterprise/Dockerfile
+++ b/3.1.0-M05/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 299048984a29d5dfb1cee3b0aa8081759f4e0bfe027092ea0a677ba1e16d6968
 ENV NEO4J_URI http://dist.neo4j.org/neo4j-enterprise-3.1.0-M05-unix.tar.gz

--- a/3.1.0-M06/community/Dockerfile
+++ b/3.1.0-M06/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 87d35c418c4159462e241a272e3619fce104cf0770ba6c71be902eb7db5049b0
 ENV NEO4J_TARBALL neo4j-community-3.1.0-M06-unix.tar.gz

--- a/3.1.0-M06/enterprise/Dockerfile
+++ b/3.1.0-M06/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 f197896ef2b67f2ead353d2bdbdd0b2a069be0de8c62a7c094ccec6bf497861d
 ENV NEO4J_TARBALL neo4j-enterprise-3.1.0-M06-unix.tar.gz

--- a/3.1.0-M07/community/Dockerfile
+++ b/3.1.0-M07/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/3.1.0-M07/enterprise/Dockerfile
+++ b/3.1.0-M07/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/3.1.0-M08/community/Dockerfile
+++ b/3.1.0-M08/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/3.1.0-M08/enterprise/Dockerfile
+++ b/3.1.0-M08/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/3.1.0-M09/community/Dockerfile
+++ b/3.1.0-M09/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/3.1.0-M09/enterprise/Dockerfile
+++ b/3.1.0-M09/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/3.1.0-M10/community/Dockerfile
+++ b/3.1.0-M10/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/3.1.0-M10/enterprise/Dockerfile
+++ b/3.1.0-M10/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/3.1.0-M12-beta2/community/Dockerfile
+++ b/3.1.0-M12-beta2/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/3.1.0-M12-beta2/enterprise/Dockerfile
+++ b/3.1.0-M12-beta2/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/3.1.0-M13-beta3/community/Dockerfile
+++ b/3.1.0-M13-beta3/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/3.1.0-M13-beta3/enterprise/Dockerfile
+++ b/3.1.0-M13-beta3/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/3.1.0-RC1/community/Dockerfile
+++ b/3.1.0-RC1/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/3.1.0-RC1/enterprise/Dockerfile
+++ b/3.1.0-RC1/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \


### PR DESCRIPTION
See https://github.com/docker-library/docs/pull/660/files#diff-5b18106a0a6d9cd97a6ecf2793c3347e (https://hub.docker.com/_/java/).