### PR TITLE
support arm64 architecture

### DIFF
--- a/3.2.3/community/Dockerfile
+++ b/3.2.3/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM arm64v8/openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \


### PR DESCRIPTION
I build docker-neo4j-publish/3.2.3/community/Dockerfile for support arm64 and success, but I don't konw NEO4J_URI=http://dist.neo4j.org/neo4j-community-3.2.3-unix.tar.gz this file whether or not support arm64 architecture, so I need some message about neo4j support arm64 architecture.