### PR TITLE
fix neo issue with stopping and starting services in the container. c…

### DIFF
--- a/4.0.0/community/docker-entrypoint.sh
+++ b/4.0.0/community/docker-entrypoint.sh
@@ -495,7 +495,8 @@ fi
 # Note that su-exec, despite its name, does not replicate the
 # functionality of exec, so we need to use both
 if [ "${cmd}" == "neo4j" ]; then
-  ${exec_cmd} neo4j console
+  gosu neo4j:neo4j neo4j start
+  tail -f /logs/neo4j.log
 else
   ${exec_cmd} "$@"
 fi


### PR DESCRIPTION
…urrently stopping neo4j in the container stops the docker container which prevents you from being able to do a dump and load of the database.