### PR TITLE
Fix bug in 5.7.0 with apoc-extended in plugins lookup table

### DIFF
--- a/5.7.0/community/local-package/neo4j-plugins.json
+++ b/5.7.0/community/local-package/neo4j-plugins.json
@@ -1,4 +1,10 @@
 {
+  "apoc-extended": {
+    "versions": "https://neo4j-contrib.github.io/neo4j-apoc-procedures/versions.json",
+    "properties": {
+      "dbms.security.procedures.unrestricted": "apoc.*"
+    }
+  },
   "apoc": {
     "location": "/var/lib/neo4j/labs/apoc-*-core.jar",
     "versions": "https://github.com/neo4j/apoc/blob/master/versions.json",

--- a/5.7.0/enterprise/local-package/neo4j-plugins.json
+++ b/5.7.0/enterprise/local-package/neo4j-plugins.json
@@ -1,4 +1,10 @@
 {
+  "apoc-extended": {
+    "versions": "https://neo4j-contrib.github.io/neo4j-apoc-procedures/versions.json",
+    "properties": {
+      "dbms.security.procedures.unrestricted": "apoc.*"
+    }
+  },
   "apoc": {
     "location": "/var/lib/neo4j/labs/apoc-*-core.jar",
     "versions": "https://github.com/neo4j/apoc/blob/master/versions.json",


### PR DESCRIPTION
Essentially the same as [this commit](https://github.com/neo4j/docker-neo4j-publish/commit/20660ac29964bba2bb7432919f65df0b7f8c323e) but for version 5.7.0